### PR TITLE
Fix network termination and SMS memory leak

### DIFF
--- a/Src/backend/modem/dispatchers/sms_dispatcher.cpp
+++ b/Src/backend/modem/dispatchers/sms_dispatcher.cpp
@@ -38,12 +38,12 @@ void SMSDispatcher::sendSMS(const QUuid &uuid, const QString &recipient, const Q
 }
 
 void SMSDispatcher::sendNextSMS() {
-    sending = true;
-    SMSTimeoout->start(15'000);
-
     if (smsQueue.isEmpty()) {
         return;
     }
+
+    sending = true;
+    SMSTimeoout->start(15'000);
 
     SMSPending *smsPending = smsQueue.head();
     qDebug() << "Sending SMS (MANAGER): " << smsPending->message;
@@ -71,11 +71,12 @@ void SMSDispatcher::onTransmitSMS(const ATCommand &command) {
     SMSTimeoout->stop();
 
     if (command.result == AT_OK) {
-        waitingDeliveryReport[messageReference++] = smsQueue.head()->uuid;
-        emit smsStatusChanged(smsQueue.head()->uuid, delivery_status_t::DS_SENT);
-        CacheManager::updateMessageStatus(smsQueue.head()->uuid, delivery_status_t::DS_SENT);
+        SMSPending *smsPending = smsQueue.dequeue();
+        waitingDeliveryReport[messageReference++] = smsPending->uuid;
+        emit smsStatusChanged(smsPending->uuid, delivery_status_t::DS_SENT);
+        CacheManager::updateMessageStatus(smsPending->uuid, delivery_status_t::DS_SENT);
         qDebug() << "SMS sent";
-        smsQueue.dequeue();
+        delete smsPending;
         sendNextSMS();
         return;
     }
@@ -91,6 +92,7 @@ void SMSDispatcher::onTransmitSMS(const ATCommand &command) {
     CacheManager::updateMessageStatus(smsPending->uuid, delivery_status_t::DS_FAILED);
     emit smsStatusChanged(smsPending->uuid, delivery_status_t::DS_FAILED);
     smsQueue.dequeue();
+    delete smsPending;
     sendNextSMS();
 }
 

--- a/Src/backend/utils/network_manager.cpp
+++ b/Src/backend/utils/network_manager.cpp
@@ -46,7 +46,9 @@ void NetworkManager::turnOnMobileData() {
 }
 
 void NetworkManager::turnOffMobileData() const {
-    pppdProcess->terminate();
+    if (pppdProcess) {
+        pppdProcess->terminate();
+    }
 }
 
 void NetworkManager::onNewPPPConnection() {


### PR DESCRIPTION
## Summary
- safely terminate mobile data connections only if running
- prevent SMS dispatcher timer from running with empty queue
- delete queued SMS objects after send or failure to avoid leaks

## Testing
- `cmake ..` *(fails: CMake 3.30+ required)*

------
https://chatgpt.com/codex/tasks/task_e_683f5e853440832f8611daaa019b1174